### PR TITLE
Fix when using Cordova, which uses file:// to load resources

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -477,7 +477,8 @@ Resource.prototype._xhrOnLoad = function () {
     var xhr = this.xhr,
         status = xhr.status !== undefined ? xhr.status : 200; //XDR has no `.status`, assume 200.
 
-    if (status === 200 || status === 204) {
+    // status can be 0 when using the file:// protocol, also check if a response was found
+    if (status === 200 || status === 204 || (status === 0 && xhr.responseText.length > 0)) {
         // if text, just return it
         if (this.xhrType === Resource.XHR_RESPONSE_TYPE.TEXT) {
             this.data = xhr.responseText;


### PR DESCRIPTION
Because the success status of an XHR request can be 0 when loading local files, loading never finished when using pixi in a cordova app.  I’ve updated the logic, which checks the status and also the length of the response is checked, to make sure a valid response was found.