### PR TITLE
Fix crossOrigin for resources on same server

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -550,10 +550,11 @@ Resource.prototype._determineCrossOrigin = function () {
     // because they don't work in IE9 :(
     tempAnchor.href = this.url;
     var url = _url.parse(tempAnchor.href),
-        loc = window.location;
+        loc = window.location,
+        samePort = (!url.port && loc.port === '') || url.port === loc.port;
 
     // if cross origin
-    if (url.hostname !== loc.hostname || url.port !== loc.port || url.protocol !== loc.protocol) {
+    if (url.hostname !== loc.hostname || !samePort || url.protocol !== loc.protocol) {
         return 'anonymous';
     }
 


### PR DESCRIPTION
Hi,

Since 814607053688eed3f44a26e6116fad8ce42f2197 the module uses `url` as a dependency, which cause an issue since `url` returns `null` when the `port` is not defined. Whereas `window.location.port` returns an empty string `''`. (https://github.com/englercj/resource-loader/blob/fb943287ccdd66a2c7055b0796b9d605b2f30874/src/Resource.js#L556)
The module used `anonymous` even if the resources were on the same server, which trigger a 401 error on my current project (it worked correctly with the previous version).

Thanks