### PR TITLE
Set testem as a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "run-sequence": "^1.0.2",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
+    "testem": "^0.8.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.1.2"


### PR DESCRIPTION
Hi,

Is it fine if we install testem as a devDep?
Like this we don't have to install it globally to run the tests :)

Thanks