### PR TITLE
add support for audio loading in CocoonJS Canvas+; fixes #18

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -315,6 +315,12 @@ Resource.prototype._loadElement = function (type) {
         this.data = document.createElement(type);
     }
 
+    if (this.data === null) {
+        this.error = new Error('Unsupported element ' + type);
+        this.complete();
+        return;
+    }
+
     // support for CocoonJS Canvas+ runtime, lacks document.createElement('source')
     if (navigator.isCocoonJS) {
         this.data.src = Array.isArray(this.url) ? this.url[0] : this.url;

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -316,7 +316,7 @@ Resource.prototype._loadElement = function (type) {
     }
 
     // support for CocoonJS Canvas+ runtime, lacks document.createElement('source')
-    if (window.CocoonJS) {
+    if (navigator.isCocoonJS) {
         this.data.src = Array.isArray(this.url) ? this.url[0] : this.url;
     }
     else {

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -308,15 +308,26 @@ Resource.prototype._loadImage = function () {
  * @private
  */
 Resource.prototype._loadElement = function (type) {
-    this.data = document.createElement(type);
-
-    if (Array.isArray(this.url)) {
-        for (var i = 0; i < this.url.length; ++i) {
-            this.data.appendChild(this._createSource(type, this.url[i]));
-        }
+    if (type === 'audio' && typeof Audio !== 'undefined') {
+        this.data = new Audio();
     }
     else {
-        this.data.appendChild(this._createSource(type, this.url));
+        this.data = document.createElement(type);
+    }
+
+    // support for CocoonJS Canvas+ runtime, lacks document.createElement('source')
+    if (window.CocoonJS) {
+        this.data.src = Array.isArray(this.url) ? this.url[0] : this.url;
+    }
+    else {
+        if (Array.isArray(this.url)) {
+            for (var i = 0; i < this.url.length; ++i) {
+                this.data.appendChild(this._createSource(type, this.url[i]));
+            }
+        }
+        else {
+            this.data.appendChild(this._createSource(type, this.url));
+        }
     }
 
     this['is' + type[0].toUpperCase() + type.substring(1)] = true;


### PR DESCRIPTION
This ended up as a CocoonJS support fix. Since its Canvas+ runtime can't create new source elements (!!!), I ended up defaulting to the first URL provided. Maybe this could all be migrated to feature detection, e.g. [canPlayType checks](https://github.com/Modernizr/Modernizr/blob/master/feature-detects/audio.js).