### PR TITLE
fix problem about get undefined resource values at "load" callback

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -420,6 +420,7 @@ Loader.prototype._onLoad = function (resource) {
 
         // do completion check
         if (this._numToLoad === 0) {
+            this.progress = 100;
             this._onComplete();
         }
         

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -412,13 +412,6 @@ Loader.prototype._onLoad = function (resource) {
 
     this.emit('progress', this, resource);
 
-    if (resource.error) {
-        this.emit('error', resource.error, this, resource);
-    }
-    else {
-        this.emit('load', this, resource);
-    }
-
     // run middleware, this *must* happen before dequeue so sub-assets get added properly
     this._runMiddleware(resource, this._afterMiddleware, function () {
         resource.emit('afterMiddleware', resource);
@@ -429,7 +422,16 @@ Loader.prototype._onLoad = function (resource) {
         if (this._numToLoad === 0) {
             this._onComplete();
         }
+        
+        if (resource.error) {
+            this.emit('error', resource.error, this, resource);
+        }
+        else {
+            this.emit('load', this, resource);
+        }
     });
+    
+
 
     // remove this resource from the async queue
     resource._dequeue();


### PR DESCRIPTION
Hi,

I made a very simple change in your loader to fix [this problem](https://github.com/pixijs/pixi.js/issues/2022).

Basically, the new fields added to the resource object returned in `load` callback, are never accessible, because the callback are trigged before set those values.

This change not broken any test, so this fix is safe.

Please let me know if my pull request makes sense and works for you.

Thanks,