### PR TITLE
Fix progress bug: Adding resources after the last resource has been loaded causes the progress to be stuck at 100%

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -251,6 +251,10 @@ Loader.prototype.add = Loader.prototype.enqueue = function (name, url, options, 
     // if already loading add it to the worker queue
     if (this._queue.started) {
         this._queue.push(this.resources[name]);
+        if (this.progress === 100) {
+            // This happens if the last resource triggers more resources to be loaded
+            this.progress = 0;
+        }
         this._progressChunk = (100 - this.progress) / (this._queue.length() + this._queue.running());
     }
     // otherwise buffer it to be added to the queue later
@@ -423,7 +427,7 @@ Loader.prototype._onLoad = function (resource) {
             this.progress = 100;
             this._onComplete();
         }
-        
+
         if (resource.error) {
             this.emit('error', resource.error, this, resource);
         }
@@ -431,7 +435,7 @@ Loader.prototype._onLoad = function (resource) {
             this.emit('load', this, resource);
         }
     });
-    
+
 
 
     // remove this resource from the async queue


### PR DESCRIPTION
Part of our asset loading process is <a href="https://github.com/gamevy/pixi-packer-parser">a middleware</a> that takes a manifest file (a bit like the spritesheet definition generated by texture packer) and triggers all of our images to be loaded.

This file might finish loading last and therefore causes progress to go to 100%. The sprites loaded subsequently get assigned a ```this._progressChunk``` of 0 and to the user it looks like the game is frozen at 100%. 

I'm not sure there's a "good" solution to this problem since we somehow need to reset progress to something lower than 100% or accept the lack of progress. This PR opts for the former and resets progress to 0 should a file be added to a loader that is already at 100%. 