### PR TITLE
Fixed: loading gets stuck after getting first asset from cache

### DIFF
--- a/src/middlewares/caching/memory.js
+++ b/src/middlewares/caching/memory.js
@@ -13,8 +13,8 @@ module.exports = function () {
             resource.once('complete', function () {
                cache[this.url] = this.data;
             });
-
-            next();
         }
+        
+        next();
     };
 };


### PR DESCRIPTION
You should call _next();_ no matter if asset was cached or not.