### PR TITLE
Add extra field in Resource for middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-loader",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "main": "./src/index.js",
   "description": "A generic asset loader, made with web games in mind.",
   "author": "Chad Engler <chad@pantherdev.com>",

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -16,7 +16,7 @@ var EventEmitter = require('eventemitter3'),
  * @param [options.loadType=Resource.LOAD_TYPE.XHR] {Resource.LOAD_TYPE} How should this resource be loaded?
  * @param [options.xhrType=Resource.XHR_RESPONSE_TYPE.DEFAULT] {Resource.XHR_RESPONSE_TYPE} How should the data being
  *      loaded be interpreted when using XHR?
- * @param [options.extra] {object} Extra info for middleware.
+ * @param [options.metadata] {object} Extra info for middleware.
  */
 function Resource(name, url, options) {
     EventEmitter.call(this);
@@ -84,7 +84,7 @@ function Resource(name, url, options) {
      *
      * @member {object}
      */
-    this.extra = options.extra || {};
+    this.metadata = options.metadata || {};
 
     /**
      * The error that occurred while loading (if any).

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -16,6 +16,7 @@ var EventEmitter = require('eventemitter3'),
  * @param [options.loadType=Resource.LOAD_TYPE.XHR] {Resource.LOAD_TYPE} How should this resource be loaded?
  * @param [options.xhrType=Resource.XHR_RESPONSE_TYPE.DEFAULT] {Resource.XHR_RESPONSE_TYPE} How should the data being
  *      loaded be interpreted when using XHR?
+ * @param [options.extra] {object} Extra info for middleware.
  */
 function Resource(name, url, options) {
     EventEmitter.call(this);
@@ -77,6 +78,13 @@ function Resource(name, url, options) {
      * @member {string}
      */
     this.xhrType = options.xhrType;
+
+    /**
+     * Extra info for middleware
+     *
+     * @member {object}
+     */
+    this.extra = options.extra || {};
 
     /**
      * The error that occurred while loading (if any).


### PR DESCRIPTION
Required for pixi-compressed-textures

```
var loader = new PIXI.loaders.Loader();
loader.before( PIXI.compressedTextures.extensionChooser(renderer) );
// use @2x texture if resolution is 2, use dds format if its windows
var textureOptions1 = { metadata: { ext: ["@2x.png", ".dds", "@2x.dds"] } };
// use dds format if its windows but dont care for retina
var textureOptions2 = { metadata: { ext: [".dds"] } };

var atlasOptions = { metadata: { imageMeta: textureOptions.extra } }

var stage = new PIXI.Container();

loader.add('building1', 'img/building1.png', textureOptions1)
    .add('building2', 'img/building2.png', textureOptions2)
    .add('IHateAtlases', 'img/atlas1.json', atlasOptions)
```