### PR TITLE
Preparing image before loading starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-loader",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "main": "./src/index.js",
   "description": "A generic asset loader, made with web games in mind.",
   "author": "Chad Engler <chad@pantherdev.com>",

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -303,7 +303,6 @@ Resource.prototype._loadImage = function () {
 
 /**
  * Prepares image for loading, but does not set src yet
- *
  */
 Resource.prototype.prepareImage = function () {
     this.data = new Image();

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -304,7 +304,6 @@ Resource.prototype._loadImage = function () {
 /**
  * Prepares image for loading, but does not set src yet
  *
- * @private
  */
 Resource.prototype.prepareImage = function () {
     this.data = new Image();

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -295,13 +295,23 @@ Resource.prototype.load = function (cb) {
  * @private
  */
 Resource.prototype._loadImage = function () {
+    if (!this.data) {
+        this.prepareImage();
+    }
+    this.data.src = this.url;
+};
+
+/**
+ * Prepares image for loading, but does not set src yet
+ *
+ * @private
+ */
+Resource.prototype.prepareImage = function () {
     this.data = new Image();
 
     if (this.crossOrigin) {
         this.data.crossOrigin = this.crossOrigin;
     }
-
-    this.data.src = this.url;
 
     this.isImage = true;
 


### PR DESCRIPTION
This thing is required for pixi-spine and pixi-compressed-textures. That way BaseTexture will be created as soon as loader adds resource, like in "fromImage" thing.