### PR TITLE
moved complete after error or load

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -418,17 +418,17 @@ Loader.prototype._onLoad = function (resource) {
 
         this._numToLoad--;
 
-        // do completion check
-        if (this._numToLoad === 0) {
-            this.progress = 100;
-            this._onComplete();
-        }
-        
         if (resource.error) {
             this.emit('error', resource.error, this, resource);
         }
         else {
             this.emit('load', this, resource);
+        }
+
+        // do completion check
+        if (this._numToLoad === 0) {
+            this.progress = 100;
+            this._onComplete();
         }
     });
     


### PR DESCRIPTION
#46 We have changed the order when load has finished.

We weren't able te run the tests

https://github.com/englercj/resource-loader/blob/master/test/unit/Resource.test.js#L32

There was a failed test due to an null value where it should be undefined.

```javascript
expect(res).to.have.property('crossOrigin', null);
```
