### PR TITLE
- fixed crash when parsedUrl.pathname is null (url is empty)

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -266,7 +266,7 @@ Loader.prototype._handleBaseUrl = function (url) {
     var parsedUrl = urlParser.parse(url);
 
     // absolute url, just use it as is.
-    if (parsedUrl.protocol || parsedUrl.pathname.indexOf('//') === 0) {
+    if (parsedUrl.protocol || parsedUrl.pathname === null || parsedUrl.pathname.indexOf('//') === 0) {
         return url;
     }
 

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -266,7 +266,7 @@ Loader.prototype._handleBaseUrl = function (url) {
     var parsedUrl = urlParser.parse(url);
 
     // absolute url, just use it as is.
-    if (parsedUrl.protocol || parsedUrl.pathname === null || parsedUrl.pathname.indexOf('//') === 0) {
+    if (parsedUrl.protocol || !parsedUrl.pathname || parsedUrl.pathname.indexOf('//') === 0) {
         return url;
     }
 


### PR DESCRIPTION
Fixed a rare crash when an empty string is used in loader. Empty string doesn't make much sense, but it's better to return "not found" rather than crashing.