### PR TITLE
Support upper case extension.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -631,7 +631,7 @@ Resource.prototype._getExtension = function () {
         ext = url.substring(url.lastIndexOf('.') + 1);
     }
 
-    return ext;
+    return ext.toLowerCase();
 };
 
 /**


### PR DESCRIPTION
This PR allows PIXI to load files with a upper case extension in order to solve http://www.html5gamedevs.com/topic/19026-jpg-image-not-working/
In my use case, I'd like to show images uploaded by users without renaming them. Actually, some users upload files with a upper case extension (e.g. .JPG).