### PR TITLE
Increment progress AFTER middleware execution

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -408,15 +408,14 @@ Loader.prototype._onComplete = function () {
  * @private
  */
 Loader.prototype._onLoad = function (resource) {
-    this.progress += this._progressChunk;
-
-    this.emit('progress', this, resource);
-
     // run middleware, this *must* happen before dequeue so sub-assets get added properly
     this._runMiddleware(resource, this._afterMiddleware, function () {
         resource.emit('afterMiddleware', resource);
 
         this._numToLoad--;
+        
+        this.progress += this._progressChunk;
+        this.emit('progress', this, resource);
 
         if (resource.error) {
             this.emit('error', resource.error, this, resource);


### PR DESCRIPTION
I'm using the progress property to update a progress bar, the bar was hanging at 100%. All downloads had completed, but my last middleware function was still executing.

Middleware functions may be long running, do not increment the progress or emit the progress event until the middleware has been executed.