### PR TITLE
Added check for when data was assigned before load

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -258,6 +258,11 @@ Resource.prototype.load = function (cb) {
         this.once('complete', cb);
     }
 
+    if (this.data) {
+        this.complete();
+        return;
+    }
+
     // if unset, determine the value
     if (this.crossOrigin === false || typeof this.crossOrigin !== 'string') {
         this.crossOrigin = this._determineCrossOrigin(this.url);

--- a/test/unit/Resource.test.js
+++ b/test/unit/Resource.test.js
@@ -127,6 +127,19 @@ describe('Resource', function () {
             expect(spy).to.have.been.calledWith(res);
         });
 
+        it('should not load and emit a complete event if data is assigned before load', function () {
+            var spy = sinon.spy();
+
+            res.on('complete', spy);
+
+            res.data = {};
+
+            res.load();
+
+            expect(request).not.to.exist;
+            expect(spy).to.have.been.calledWith(res);
+        });
+
         it('should load using a data url', function (done) {
             var res = new Resource(name, dataUrl);
 


### PR DESCRIPTION
Even if a 'before' middleware assigns to a `Resource`'s data and calls `complete()` the resource will still load from the network. This prevents cache style middleware from functioning correctly.

Added a check for the existence of `data` during load and call `complete` if it exists.

Fixes #57