### PR TITLE
Fix #57 - Proper handling of 'before' middleware

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -44,6 +44,14 @@ function Resource(name, url, options) {
     this.url = url;
 
     /**
+     * Stores whether or not this url is a data url.
+     *
+     * @member {boolean}
+     * @readonly
+     */
+    this.isDataUrl = this.url.indexOf('data:') === 0;
+
+    /**
      * The data that was loaded by the resource.
      *
      * @member {any}
@@ -56,14 +64,6 @@ function Resource(name, url, options) {
      * @member {string}
      */
     this.crossOrigin = options.crossOrigin === true ? 'anonymous' : options.crossOrigin;
-
-    /**
-     * Stores whether or not this url is a data url.
-     *
-     * @member {boolean}
-     * @readonly
-     */
-    this.isDataUrl = this.url.indexOf('data:') === 0;
 
     /**
      * The method of loading to use for this resource.

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -44,14 +44,6 @@ function Resource(name, url, options) {
     this.url = url;
 
     /**
-     * Stores whether or not this url is a data url.
-     *
-     * @member {boolean}
-     * @readonly
-     */
-    this.isDataUrl = this.url.indexOf('data:') === 0;
-
-    /**
      * The data that was loaded by the resource.
      *
      * @member {any}
@@ -64,6 +56,14 @@ function Resource(name, url, options) {
      * @member {string}
      */
     this.crossOrigin = options.crossOrigin === true ? 'anonymous' : options.crossOrigin;
+
+    /**
+     * Stores whether or not this url is a data url.
+     *
+     * @member {boolean}
+     * @readonly
+     */
+    this.isDataUrl = this.url.indexOf('data:') === 0;
 
     /**
      * The method of loading to use for this resource.
@@ -141,6 +141,14 @@ function Resource(name, url, options) {
      * @member {boolean}
      */
     this.isVideo = false;
+
+    /**
+     * Describes if this resource has finished loading. is true when the resource has completely
+     * loaded.
+     *
+     * @member {boolean}
+     */
+    this.isComplete = false;
 
     /**
      * The `dequeue` method that will be used a storage place for the async queue dequeue method
@@ -241,11 +249,16 @@ Resource.prototype.complete = function () {
         }
     }
 
+    if (this.isComplete) {
+        throw new Error('Complete called again for an already completed resource.');
+    }
+
+    this.isComplete = true;
     this.emit('complete', this);
 };
 
 /**
- * Kicks off loading of this resource.
+ * Kicks off loading of this resource. This method is asynchronous.
  *
  * @fires start
  * @param [callback] {function} Optional callback to call once the resource is loaded.
@@ -253,8 +266,18 @@ Resource.prototype.complete = function () {
 Resource.prototype.load = function (cb) {
     this.emit('start', this);
 
-    // if a callback is set, listen for complete event
-    if (cb) {
+    if (this.isComplete) {
+        if (cb) {
+            var self = this;
+
+            setTimeout(function () {
+                cb(self);
+            }, 1);
+        }
+
+        return;
+    }
+    else if (cb) {
         this.once('complete', cb);
     }
 

--- a/src/middlewares/caching/memory.js
+++ b/src/middlewares/caching/memory.js
@@ -6,15 +6,15 @@ module.exports = function () {
         // if cached, then set data and complete the resource
         if (cache[resource.url]) {
             resource.data = cache[resource.url];
-            resource.complete();
+            resource.complete(); // marks resource load complete and stops processing before middlewares
         }
         // if not cached, wait for complete and store it in the cache.
         else {
             resource.once('complete', function () {
-               cache[this.url] = this.data;
+                cache[this.url] = this.data;
             });
         }
-        
+
         next();
     };
 };

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -3,4 +3,6 @@ window.fixtureData = {
     baseUrl: '/fixtures',
     dataUrlGif: 'data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==',
     dataUrlSvg: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMCcgaGVpZ2h0PSczMCc+PGNpcmNsZSBjeD0nMTUnIGN5PScxNScgcj0nMTAnIC8+PC9zdmc+',
+    dataJson: '[{ "id": 12, "comment": "Hey there" }]',
+    dataJsonHeaders: { 'Content-Type': 'application/json' },
 };

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -1,0 +1,6 @@
+window.fixtureData = {
+    url: 'http://localhost/file',
+    baseUrl: '/fixtures',
+    dataUrlGif: 'data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==',
+    dataUrlSvg: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMCcgaGVpZ2h0PSczMCc+PGNpcmNsZSBjeD0nMTUnIGN5PScxNScgcj0nMTAnIC8+PC9zdmc+',
+};

--- a/test/unit/Loader.test.js
+++ b/test/unit/Loader.test.js
@@ -1,13 +1,12 @@
-var loader = null,
-    baseUrl = '/fixtures';
+var loader = null;
 
 describe('Loader', function () {
     beforeEach(function () {
-        loader = new Loader(baseUrl);
+        loader = new Loader(fixtureData.baseUrl);
     });
 
     it('should have correct properties', function () {
-        expect(loader).to.have.property('baseUrl', baseUrl);
+        expect(loader).to.have.property('baseUrl', fixtureData.baseUrl);
         expect(loader).to.have.property('progress', 0);
     });
 
@@ -21,7 +20,6 @@ describe('Loader', function () {
 
     describe('#add', function () {
         var name = 'test-resource',
-            url = 'http://localhost/file',
             options = {
                 crossOrigin: true,
                 loadType: Resource.LOAD_TYPE.IMAGE,
@@ -30,7 +28,7 @@ describe('Loader', function () {
             callback = function () {};
 
         it('creates a resource using all arguments', function () {
-            loader.add(name, url, options, callback);
+            loader.add(name, fixtureData.url, options, callback);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -39,7 +37,7 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
             expect(res).to.have.property('crossOrigin', options.crossOrigin ? 'anonymous' : null);
             expect(res).to.have.property('loadType', options.loadType);
             expect(res).to.have.property('xhrType', options.xhrType);
@@ -49,7 +47,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just name, url, and options', function () {
-            loader.add(name, url, options);
+            loader.add(name, fixtureData.url, options);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -58,14 +56,14 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
             expect(res).to.have.property('crossOrigin', options.crossOrigin ? 'anonymous' : null);
             expect(res).to.have.property('loadType', options.loadType);
             expect(res).to.have.property('xhrType', options.xhrType);
         });
 
         it('creates a resource with just name, url, and a callback', function () {
-            loader.add(name, url, callback);
+            loader.add(name, fixtureData.url, callback);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -74,7 +72,7 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
 
             expect(res.listeners('afterMiddleware'))
                 .to.not.be.empty
@@ -82,7 +80,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just name and url', function () {
-            loader.add(name, url);
+            loader.add(name, fixtureData.url);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -91,11 +89,11 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
         });
 
         it('creates a resource with just url, options, and a callback', function () {
-            loader.add(url, options, callback);
+            loader.add(fixtureData.url, options, callback);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -103,8 +101,8 @@ describe('Loader', function () {
             var res = loader._buffer[0];
 
             expect(res).to.be.an.instanceOf(Resource);
-            expect(res).to.have.property('name', url);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('name', fixtureData.url);
+            expect(res).to.have.property('url', fixtureData.url);
             expect(res).to.have.property('crossOrigin', options.crossOrigin ? 'anonymous' : null);
             expect(res).to.have.property('loadType', options.loadType);
             expect(res).to.have.property('xhrType', options.xhrType);
@@ -115,7 +113,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just url and options', function () {
-            loader.add(url, options);
+            loader.add(fixtureData.url, options);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -123,15 +121,15 @@ describe('Loader', function () {
             var res = loader._buffer[0];
 
             expect(res).to.be.an.instanceOf(Resource);
-            expect(res).to.have.property('name', url);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('name', fixtureData.url);
+            expect(res).to.have.property('url', fixtureData.url);
             expect(res).to.have.property('crossOrigin', options.crossOrigin ? 'anonymous' : null);
             expect(res).to.have.property('loadType', options.loadType);
             expect(res).to.have.property('xhrType', options.xhrType);
         });
 
         it('creates a resource with just url and a callback', function () {
-            loader.add(url, callback);
+            loader.add(fixtureData.url, callback);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -139,8 +137,8 @@ describe('Loader', function () {
             var res = loader._buffer[0];
 
             expect(res).to.be.an.instanceOf(Resource);
-            expect(res).to.have.property('name', url);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('name', fixtureData.url);
+            expect(res).to.have.property('url', fixtureData.url);
 
             expect(res.listeners('afterMiddleware'))
                 .to.not.be.empty
@@ -148,7 +146,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just url', function () {
-            loader.add(url);
+            loader.add(fixtureData.url);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -156,12 +154,12 @@ describe('Loader', function () {
             var res = loader._buffer[0];
 
             expect(res).to.be.an.instanceOf(Resource);
-            expect(res).to.have.property('name', url);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('name', fixtureData.url);
+            expect(res).to.have.property('url', fixtureData.url);
         });
 
         it('creates a resource with just an object (name/url keys) and callback param', function () {
-            loader.add({ name: name, url: url }, callback);
+            loader.add({ name: name, url: fixtureData.url }, callback);
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -170,7 +168,7 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
 
             expect(res.listeners('afterMiddleware'))
                 .to.not.be.empty
@@ -178,7 +176,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just an object (name/url/callback keys)', function () {
-            loader.add({ name: name, url: url, onComplete: callback });
+            loader.add({ name: name, url: fixtureData.url, onComplete: callback });
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -187,7 +185,7 @@ describe('Loader', function () {
 
             expect(res).to.be.an.instanceOf(Resource);
             expect(res).to.have.property('name', name);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('url', fixtureData.url);
 
             expect(res.listeners('afterMiddleware'))
                 .to.not.be.empty
@@ -195,7 +193,7 @@ describe('Loader', function () {
         });
 
         it('creates a resource with just an object (url/callback keys)', function () {
-            loader.add({ url: url, onComplete: callback });
+            loader.add({ url: fixtureData.url, onComplete: callback });
 
             expect(loader._queue.length()).to.equal(0);
             expect(loader._buffer).to.have.length(1);
@@ -203,8 +201,8 @@ describe('Loader', function () {
             var res = loader._buffer[0];
 
             expect(res).to.be.an.instanceOf(Resource);
-            expect(res).to.have.property('name', url);
-            expect(res).to.have.property('url', url);
+            expect(res).to.have.property('name', fixtureData.url);
+            expect(res).to.have.property('url', fixtureData.url);
 
             expect(res.listeners('afterMiddleware'))
                 .to.not.be.empty
@@ -281,9 +279,72 @@ describe('Loader', function () {
     });
 
     describe('#load', function () {
-        it('should run the `before` middleware, before loading a resource');
-        it('should run the `after` middleware, after loading a resource');
-        it('should properly load the resource');
+        it('should run the `before` middleware, before loading a resource', function (done) {
+            var spy = sinon.spy(function (res, next) { next(); });
+            var spy2 = sinon.spy(function (res, next) { next(); });
+
+            loader.pre(spy);
+            loader.pre(spy2);
+
+            loader.add(fixtureData.dataUrlGif);
+
+            loader.load(function () {
+                expect(spy).to.have.been.calledOnce;
+                expect(spy2).to.have.been.calledOnce;
+                done();
+            });
+        });
+
+        it('should stop running the `before` middleware when one calls complete()', function (done) {
+            var spy = sinon.spy(function (res, next) { res.complete(); next(); });
+            var spy2 = sinon.spy(function (res, next) { next(); });
+
+            loader.pre(spy);
+            loader.pre(spy2);
+
+            loader.add(fixtureData.dataUrlGif);
+
+            loader.load(function () {
+                expect(spy).to.have.been.calledOnce;
+                expect(spy2).to.have.not.been.called;
+                done();
+            });
+        });
+
+        it('should run the `after` middleware, after loading a resource', function (done) {
+            var spy = sinon.spy(function (res, next) { next(); });
+            var spy2 = sinon.spy(function (res, next) { next(); });
+
+            loader.use(spy);
+            loader.use(spy2);
+
+            loader.add(fixtureData.dataUrlGif);
+
+            loader.load(function () {
+                expect(spy).to.have.been.calledOnce;
+                expect(spy2).to.have.been.calledOnce;
+                done();
+            });
+        });
+
+        it('should properly load the resource', function (done) {
+            var spy = sinon.spy(function (loader, resources) {
+                expect(spy).to.have.been.calledOnce;
+                expect(loader.progress).to.equal(100);
+                expect(loader.loading).to.equal(false);
+                expect(loader.resources).to.equal(resources);
+
+                expect(resources).to.not.be.empty;
+                expect(resources.res).to.be.ok;
+                expect(resources.res.isComplete).to.be.true;
+
+                done();
+            });
+
+            loader.add('res', fixtureData.dataUrlGif);
+
+            loader.load(spy);
+        });
     });
 
     describe('#_loadResource', function () {
@@ -309,26 +370,6 @@ describe('Loader', function () {
         it('should emit the `error` event when the resource has an error');
         it('should emit the `load` event when the resource loads successfully');
         it('should run the after middleware');
-    });
-
-    describe('#_runMiddleware', function () {
-        it('should run each middleware function', function () {
-            var res = {},
-                noop = function () {};
-
-            var spy = sinon.spy(function (resource, next) {
-                expect(resource).to.equal(res);
-                next();
-            });
-
-            loader.pre(spy).before(spy);
-
-            expect(loader._beforeMiddleware).to.have.length(2);
-
-            loader._runMiddleware(res, loader._beforeMiddleware, noop);
-
-            expect(spy).to.have.been.calledTwice;
-        });
     });
 
     describe('events', function () {

--- a/test/unit/Resource.test.js
+++ b/test/unit/Resource.test.js
@@ -1,10 +1,7 @@
 var request,
     res,
     xhr,
-    name = 'test-resource',
-    url = 'http://localhost/file',
-    headers = { 'Content-Type': 'application/json' },
-    json = '[{ "id": 12, "comment": "Hey there" }]';
+    name = 'test-resource';
 
 describe('Resource', function () {
     before(function () {
@@ -17,13 +14,13 @@ describe('Resource', function () {
     });
 
     beforeEach(function () {
-        res = new Resource(name, url);
+        res = new Resource(name, fixtureData.url);
         request = null;
     });
 
     it('should construct properly with only a URL passed', function () {
         expect(res).to.have.property('name', name);
-        expect(res).to.have.property('url', url);
+        expect(res).to.have.property('url', fixtureData.url);
         expect(res).to.have.property('data', null);
         expect(res).to.have.property('crossOrigin', undefined);
         expect(res).to.have.property('loadType', Resource.LOAD_TYPE.XHR);
@@ -43,7 +40,7 @@ describe('Resource', function () {
 
     it('should construct properly with options passed', function () {
         var meta = { some: 'thing' };
-        var res = new Resource(name, url, {
+        var res = new Resource(name, fixtureData.url, {
             crossOrigin: true,
             loadType: Resource.LOAD_TYPE.IMAGE,
             xhrType: Resource.XHR_RESPONSE_TYPE.BLOB,
@@ -51,7 +48,7 @@ describe('Resource', function () {
         });
 
         expect(res).to.have.property('name', name);
-        expect(res).to.have.property('url', url);
+        expect(res).to.have.property('url', fixtureData.url);
         expect(res).to.have.property('data', null);
         expect(res).to.have.property('crossOrigin', 'anonymous');
         expect(res).to.have.property('loadType', Resource.LOAD_TYPE.IMAGE);
@@ -136,7 +133,7 @@ describe('Resource', function () {
 
             res.load();
 
-            request.respond(200, headers, json);
+            request.respond(200, fixtureData.dataJsonHeaders, fixtureData.dataJson);
 
             expect(request).to.exist;
             expect(spy).to.have.been.calledWith(res);
@@ -191,7 +188,7 @@ describe('Resource', function () {
 
         it('should load using XHR', function (done) {
             res.on('complete', function () {
-                expect(res).to.have.property('data', json);
+                expect(res).to.have.property('data', fixtureData.dataJson);
                 done();
             });
 
@@ -199,11 +196,11 @@ describe('Resource', function () {
 
             expect(request).to.exist;
 
-            request.respond(200, headers, json);
+            request.respond(200, fixtureData.dataJsonHeaders, fixtureData.dataJson);
         });
 
         it('should load using Image', function () {
-            var res = new Resource(name, url, { loadType: Resource.LOAD_TYPE.IMAGE });
+            var res = new Resource(name, fixtureData.url, { loadType: Resource.LOAD_TYPE.IMAGE });
 
             res.load();
 
@@ -211,11 +208,11 @@ describe('Resource', function () {
 
             expect(res).to.have.property('data').instanceOf(Image)
                 .and.is.an.instanceOf(HTMLImageElement)
-                .and.have.property('src', url);
+                .and.have.property('src', fixtureData.url);
         });
 
         it('should load using Audio', function () {
-            var res = new Resource(name, url, { loadType: Resource.LOAD_TYPE.AUDIO });
+            var res = new Resource(name, fixtureData.url, { loadType: Resource.LOAD_TYPE.AUDIO });
 
             res.load();
 
@@ -224,11 +221,11 @@ describe('Resource', function () {
             expect(res).to.have.property('data').instanceOf(HTMLAudioElement);
 
             expect(res.data.children).to.have.length(1);
-            expect(res.data.children[0]).to.have.property('src', url);
+            expect(res.data.children[0]).to.have.property('src', fixtureData.url);
         });
 
         it('should load using Video', function () {
-            var res = new Resource(name, url, { loadType: Resource.LOAD_TYPE.VIDEO });
+            var res = new Resource(name, fixtureData.url, { loadType: Resource.LOAD_TYPE.VIDEO });
 
             res.load();
 
@@ -237,7 +234,7 @@ describe('Resource', function () {
             expect(res).to.have.property('data').instanceOf(HTMLVideoElement);
 
             expect(res.data.children).to.have.length(1);
-            expect(res.data.children[0]).to.have.property('src', url);
+            expect(res.data.children[0]).to.have.property('src', fixtureData.url);
         });
     });
 

--- a/testem.json
+++ b/testem.json
@@ -5,6 +5,7 @@
     "launch_in_ci": ["Firefox"],
     "src_files": [
         "dist/resource-loader.js",
+        "test/fixtures/data.js",
         "test/unit/**/*.test.js"
     ],
     "serve_files": [
@@ -17,6 +18,7 @@
         "test/setup.js",
         "test/fixtures/spritesheetMiddleware.js",
 
+        "test/fixtures/data.js",
         "test/unit/**/*.test.js"
     ],
     "routes": {


### PR DESCRIPTION
Alternative to #61, a bit more robust checks in different places and includes a small refactor of running middleware.

New behavior of `pre` middleware:

-  Each is called in sequence
- If any middleware calls `complete()` execution of middleware stops and the resource's `load()` is called
- If the resource is complete at the time of calling `load()` it exits
- If `complete()` is called more than once an error is thrown.

Also adds some additional tests and moves some data into a fixture file.