### PR TITLE
Fix the issue with npm publish not including those folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "keywords": [],
   "files": [
-    "./dist",
-    "./src"
+    "dist",
+    "src"
   ],
   "scripts": {
     "test": "npm run build && testem ci",


### PR DESCRIPTION
The current version ```1.6.7``` seems to come without the "src" or "dist" folder when fetched from npm:
```sh
~/w/pixi-packer-parser (master) $ rm -rf node_modules/resource-loader/
~/w/pixi-packer-parser (master) $ npm install
resource-loader@1.6.7 node_modules/resource-loader
├── eventemitter3@1.2.0
└── async@2.0.1 (lodash@4.14.0)
~/w/pixi-packer-parser (master) $ ls node_modules/resource-loader/
LICENSE      README.md    node_modules package.json
```

I've looked through the recent changes and I feel like this should fix it - It's one of those things very hard to test without actually doing it though :(