### PR TITLE
Expose the extension publicly

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -92,6 +92,14 @@ export default class Resource {
         this.url = url;
 
         /**
+         * The extension used to load this resource.
+         *
+         * @member {string}
+         * @readonly
+         */
+        this.extension = this._getExtension();
+
+        /**
          * The data that was loaded by the resource.
          *
          * @member {any}
@@ -815,7 +823,7 @@ export default class Resource {
      * @return {Resource.XHR_RESPONSE_TYPE} The responseType to use.
      */
     _determineXhrType() {
-        return Resource._xhrTypeMap[this._getExtension()] || Resource.XHR_RESPONSE_TYPE.TEXT;
+        return Resource._xhrTypeMap[this.extension] || Resource.XHR_RESPONSE_TYPE.TEXT;
     }
 
     /**
@@ -826,7 +834,7 @@ export default class Resource {
      * @return {Resource.LOAD_TYPE} The loadType to use.
      */
     _determineLoadType() {
-        return Resource._loadTypeMap[this._getExtension()] || Resource.LOAD_TYPE.XHR;
+        return Resource._loadTypeMap[this.extension] || Resource.LOAD_TYPE.XHR;
     }
 
     /**


### PR DESCRIPTION
## Overview

This PR exposes the file/url extension to be a publicly accessible property of Resource. Currently, the only way to get the extension is by calling the private method `_getExtension()`.

I needed this so that it's easier to compare against the extension when creating custom middleware:

```js
function middleware(resource, next) {
    if (resource.data && resource.extension === 'blah') {
        // do something
    }
    next();
}
