### PR TITLE
Moved dequeue to after push to _resourcesParsing

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -538,8 +538,8 @@ export default class Loader {
         resource._onLoadBinding = null;
 
         // remove this resource from the async queue, and add it to our list of resources that are being parsed
-        resource._dequeue();
         this._resourcesParsing.push(resource);
+        resource._dequeue();
 
         // run all the after middleware for this resource
         async.eachSeries(

--- a/test/unit/Loader.test.js
+++ b/test/unit/Loader.test.js
@@ -338,6 +338,24 @@ describe('Loader', () => {
             });
         });
 
+        it ('should still run `after` middleware for all resources that have been completed in `before` middleware', (done) => {
+
+            const spy = sinon.spy((res, next) => next());
+
+            loader
+                .pre((res, next) => {
+                    res.complete();
+                    next();
+                })
+                .use(spy)
+                .add(fixtureData.dataUrlGif)
+                .add(fixtureData.url)
+                .load(() => {
+                    expect(spy).to.have.been.calledTwice;
+                    done();
+                });
+        });
+
         it('should properly load the resource', (done) => {
             const spy = sinon.spy((loader, resources) => {
                 expect(spy).to.have.been.calledOnce;

--- a/test/unit/Loader.test.js
+++ b/test/unit/Loader.test.js
@@ -338,8 +338,7 @@ describe('Loader', () => {
             });
         });
 
-        it ('should still run `after` middleware for all resources that have been completed in `before` middleware', (done) => {
-
+        it('should run `after` middleware for resources that have been completed in `before` middleware', (done) => {
             const spy = sinon.spy((res, next) => next());
 
             loader


### PR DESCRIPTION
A situation can arise when there's 2 resources being loaded with the second one being a sprite-sheet. Sprite-sheets require an `after` middleware to add extra files to be loaded (the sprite-sheet image itself)

If the call to `dequeue` happens on the sprite-sheet resource and the `_onLoad` of the previous resource is on the queue, then the `_onLoad` is resumed. The `after` middleware will be run the first resource and when it is spliced out of `_resourcesParsing` in the `async.eachSeries` completion callback the sprite-sheet resource will not be in `_resourcesParsing`. `_resourcesParsing` is now empty and `_onComplete` is called. The `after` middleware is not run before on the sprite-sheet and thus it hasn't loaded its associated texture

If you have code relying on the texture to be loaded when `onComplete` is called then it will not be loaded at that point

The fix is to move the push to `_resourcesParsing` to before the `dequeue` in order to ensure its present when any previously queued `_onLoad` calls are executed

This fixes #91