### PR TITLE
Adds the ability to change concurrency on-the-fly

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -438,7 +438,7 @@ export default class Loader {
 
         return this;
     }
-    
+
     /**
      * The number of resources to load concurrently.
      *
@@ -446,10 +446,11 @@ export default class Loader {
      * @default 10
      */
     get concurrency() {
-        return this._queue.concurrency;   
+        return this._queue.concurrency;
     }
+    // eslint-disable-next-line require-jsdoc
     set concurrency(concurrency) {
-        this._queue.concurrency = concurrency;   
+        this._queue.concurrency = concurrency;
     }
 
     /**

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -438,6 +438,19 @@ export default class Loader {
 
         return this;
     }
+    
+    /**
+     * The number of resources to load concurrently.
+     *
+     * @member {number}
+     * @default 10
+     */
+    get concurrency() {
+        return this._queue.concurrency;   
+    }
+    set concurrency(concurrency) {
+        this._queue.concurrency = concurrency;   
+    }
 
     /**
      * Prepares a url for usage based on the configuration of this object


### PR DESCRIPTION
Async docs for [QueueObject](https://caolan.github.io/async/docs.html#QueueObject) indicates that `concurrency` can be altered on-the-fly. This would provide some flexibility in adjusting this amount after Loader has been created, e.g., `PIXI.loader`.

@funkypaul reported this issue to me while trying to reduce the concurrency load for IE 11. While a solution which directly fixes this issue would be better, I still think there's value in adding a `concurrency` member.