### PR TITLE
Replaces Jaguar template with Pixi template

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -34,6 +34,6 @@
         "private"       : false,
         "lenient"       : true,
         "destination"   : "./docs",
-        "template"      : "./node_modules/jaguarjs-jsdoc"
+        "template"      : "./node_modules/@pixi/jsdoc-template"
     }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@englercj/code-style": "^1.0.6",
+    "@pixi/jsdoc-template": "^2.2.0",
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "browserify": "^13.1.1",
@@ -54,7 +55,6 @@
     "eslint": "^3.12.2",
     "gh-pages": "^0.12.0",
     "ink-docstrap": "^1.3.0",
-    "jaguarjs-jsdoc": "^1.0.2",
     "jsdoc": "^3.4.3",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
Replaces jaguarjs-jsdoc template with @pixi/jsdoc-template. Adds support for mobile docs

**Preview**

http://mattkarl.com/resource-loader/Resource.html

## Before
![screen shot 2017-11-07 at 5 08 04 pm](https://user-images.githubusercontent.com/864393/32520656-bb32a446-c3de-11e7-81c2-cff6526c92b8.png)

## After
![screen shot 2017-11-07 at 5 07 41 pm](https://user-images.githubusercontent.com/864393/32520657-bb42e194-c3de-11e7-87b0-4dcb2bea0968.png)
