### PR TITLE
Added async queues for both before & after middleware processing

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -16,6 +16,7 @@ export default class Loader {
     /**
      * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.
      * @param {number} [concurrency=10] - The number of resources to load concurrently.
+     * @param {number} [middlewareConcurrency=1] - The number of resources to execute middlewares on concurrently.
      */
     constructor(baseUrl = '', concurrency = 10, middlewareConcurrency = 1) {
         /**
@@ -496,7 +497,7 @@ export default class Loader {
     // eslint-disable-next-line require-jsdoc
     set middlewareConcurrency(concurrency) {
         this._beforeMiddlewareQueue.concurrency = concurrency;
-		this._afterMiddlewareQueue.concurrency = concurrency;
+        this._afterMiddlewareQueue.concurrency = concurrency;
     }
 
     /**
@@ -555,7 +556,7 @@ export default class Loader {
         resource._dequeue = dequeue;
 
 		// add to before middleware execution queue
-		this._beforeMiddlewareQueue.push(resource);
+        this._beforeMiddlewareQueue.push(resource);
     }
 
     /**
@@ -579,8 +580,8 @@ export default class Loader {
         resource._onLoadBinding = null;
 
 		// add to after middleware execution queue
-		this._afterMiddlewareQueue.push(resource);
-		
+        this._afterMiddlewareQueue.push(resource);
+
         // remove this resource from the async queue
         resource._dequeue();
     }
@@ -611,11 +612,11 @@ export default class Loader {
                     resource._onLoadBinding = resource.onComplete.once(this._onLoad, this);
                     resource.load();
                 }
-				dequeue();
+                dequeue();
             },
             true
         );
-	}
+    }
 
     /**
      * Executes the after middlewares on a given resource.
@@ -644,15 +645,15 @@ export default class Loader {
                     this.onLoad.dispatch(this, resource);
                 }
 
-				dequeue();
+                dequeue();
 
                 // do completion check
-                if (this._queue.idle() && this._beforeMiddlewareQueue.idle() && this._afterMiddlewareQueue.idle() ) {
+                if (this._queue.idle() && this._beforeMiddlewareQueue.idle() && this._afterMiddlewareQueue.idle()) {
                     this.progress = MAX_PROGRESS;
                     this._onComplete();
                 }
             },
             true
         );
-	}
+    }
 }

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -17,7 +17,7 @@ export default class Loader {
      * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.
      * @param {number} [concurrency=10] - The number of resources to load concurrently.
      */
-    constructor(baseUrl = '', concurrency = 10) {
+    constructor(baseUrl = '', concurrency = 10, middlewareConcurrency = 1) {
         /**
          * The base url for all resources loaded by this loader.
          *
@@ -76,13 +76,6 @@ export default class Loader {
         this._afterMiddleware = [];
 
         /**
-         * The tracks the resources we are currently completing parsing for.
-         *
-         * @member {Resource[]}
-         */
-        this._resourcesParsing = [];
-
-        /**
          * The `_loadResource` function bound with this object context.
          *
          * @private
@@ -109,6 +102,44 @@ export default class Loader {
          * @member {object<string, Resource>}
          */
         this.resources = {};
+
+        /**
+         * The `_executeBeforeMiddleware` function bound with this object context.
+         *
+         * @private
+         * @member {function}
+         * @param {Resource} r - The resource to load
+         * @param {Function} d - The dequeue function
+         * @return {undefined}
+         */
+        this._boundExecuteBeforeMiddleware = (r, d) => this._executeBeforeMiddleware(r, d);
+
+        /**
+         * The before middleware resources waiting to be executed.
+         *
+         * @private
+         * @member {Resource[]}
+         */
+        this._beforeMiddlewareQueue = async.queue(this._boundExecuteBeforeMiddleware, middlewareConcurrency);
+
+        /**
+         * The `_executeAfterMiddleware` function bound with this object context.
+         *
+         * @private
+         * @member {function}
+         * @param {Resource} r - The resource to load
+         * @param {Function} d - The dequeue function
+         * @return {undefined}
+         */
+        this._boundExecuteAfterMiddleware = (r, d) => this._executeAfterMiddleware(r, d);
+
+        /**
+         * The after middleware resources waiting to be executed.
+         *
+         * @private
+         * @member {Resource[]}
+         */
+        this._afterMiddlewareQueue = async.queue(this._boundExecuteAfterMiddleware, middlewareConcurrency);
 
         /**
          * Dispatched once per loaded or errored resource.
@@ -454,6 +485,21 @@ export default class Loader {
     }
 
     /**
+     * The number of resources to execute the middleware code on.
+     *
+     * @member {number}
+     * @default 1
+     */
+    get middlewareConcurrency() {
+        return this._afterMiddlewareQueue.concurrency;
+    }
+    // eslint-disable-next-line require-jsdoc
+    set middlewareConcurrency(concurrency) {
+        this._beforeMiddlewareQueue.concurrency = concurrency;
+		this._afterMiddlewareQueue.concurrency = concurrency;
+    }
+
+    /**
      * Prepares a url for usage based on the configuration of this object
      *
      * @private
@@ -508,27 +554,8 @@ export default class Loader {
     _loadResource(resource, dequeue) {
         resource._dequeue = dequeue;
 
-        // run before middleware
-        async.eachSeries(
-            this._beforeMiddleware,
-            (fn, next) => {
-                fn.call(this, resource, () => {
-                    // if the before middleware marks the resource as complete,
-                    // break and don't process any more before middleware
-                    next(resource.isComplete ? {} : null);
-                });
-            },
-            () => {
-                if (resource.isComplete) {
-                    this._onLoad(resource);
-                }
-                else {
-                    resource._onLoadBinding = resource.onComplete.once(this._onLoad, this);
-                    resource.load();
-                }
-            },
-            true
-        );
+		// add to before middleware execution queue
+		this._beforeMiddlewareQueue.push(resource);
     }
 
     /**
@@ -551,10 +578,53 @@ export default class Loader {
     _onLoad(resource) {
         resource._onLoadBinding = null;
 
-        // remove this resource from the async queue, and add it to our list of resources that are being parsed
-        this._resourcesParsing.push(resource);
+		// add to after middleware execution queue
+		this._afterMiddlewareQueue.push(resource);
+		
+        // remove this resource from the async queue
         resource._dequeue();
+    }
 
+    /**
+     * Executes the before middlewares on a given resource.
+     *
+     * @private
+     * @param {Resource} resource - The resource to execute the middleware on.
+     * @param {function} dequeue - The function to call when we need to dequeue this item.
+     */
+    _executeBeforeMiddleware(resource, dequeue) {
+        // run before middleware
+        async.eachSeries(
+            this._beforeMiddleware,
+            (fn, next) => {
+                fn.call(this, resource, () => {
+                    // if the before middleware marks the resource as complete,
+                    // break and don't process any more before middleware
+                    next(resource.isComplete ? {} : null);
+                });
+            },
+            () => {
+                if (resource.isComplete) {
+                    this._onLoad(resource);
+                }
+                else {
+                    resource._onLoadBinding = resource.onComplete.once(this._onLoad, this);
+                    resource.load();
+                }
+				dequeue();
+            },
+            true
+        );
+	}
+
+    /**
+     * Executes the after middlewares on a given resource.
+     *
+     * @private
+     * @param {Resource} resource - The resource to execute the middleware on.
+     * @param {function} dequeue - The function to call when we need to dequeue this item.
+     */
+    _executeAfterMiddleware(resource, dequeue) {
         // run all the after middleware for this resource
         async.eachSeries(
             this._afterMiddleware,
@@ -574,15 +644,15 @@ export default class Loader {
                     this.onLoad.dispatch(this, resource);
                 }
 
-                this._resourcesParsing.splice(this._resourcesParsing.indexOf(resource), 1);
+				dequeue();
 
                 // do completion check
-                if (this._queue.idle() && this._resourcesParsing.length === 0) {
+                if (this._queue.idle() && this._beforeMiddlewareQueue.idle() && this._afterMiddlewareQueue.idle() ) {
                     this.progress = MAX_PROGRESS;
                     this._onComplete();
                 }
             },
             true
         );
-    }
+	}
 }

--- a/test/unit/Loader.test.js
+++ b/test/unit/Loader.test.js
@@ -482,14 +482,18 @@ describe('Loader', () => {
             }, 16);
         });
 
-        it('should load a resource passed into it', () => {
+        it('should load a resource passed into it', (done) => {
             const res = new Loader.Resource('mock', fixtureData.url);
 
             res.load = sinon.spy();
 
             loader._loadResource(res);
 
-            expect(res.load).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(res.load).to.have.been.calledOnce;
+
+                done();
+            }, 16);
         });
     });
 
@@ -507,7 +511,7 @@ describe('Loader', () => {
     });
 
     describe('#_onLoad', () => {
-        it('should emit the `progress` event', () => {
+        it('should emit the `progress` event', (done) => {
             const res = new Loader.Resource('mock', fixtureData.url);
             const spy = sinon.spy();
 
@@ -517,10 +521,13 @@ describe('Loader', () => {
 
             loader._onLoad(res);
 
-            expect(spy).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(spy).to.have.been.calledOnce;
+                done();
+            }, 16);
         });
 
-        it('should emit the `error` event when the resource has an error', () => {
+        it('should emit the `error` event when the resource has an error', (done) => {
             const res = new Loader.Resource('mock', fixtureData.url);
             const spy = sinon.spy();
 
@@ -532,10 +539,13 @@ describe('Loader', () => {
 
             loader._onLoad(res);
 
-            expect(spy).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(spy).to.have.been.calledOnce;
+                done();
+            }, 16);
         });
 
-        it('should emit the `load` event when the resource loads successfully', () => {
+        it('should emit the `load` event when the resource loads successfully', (done) => {
             const res = new Loader.Resource('mock', fixtureData.url);
             const spy = sinon.spy();
 
@@ -545,7 +555,10 @@ describe('Loader', () => {
 
             loader._onLoad(res);
 
-            expect(spy).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(spy).to.have.been.calledOnce;
+                done();
+            }, 16);
         });
 
         it('should run the after middleware', (done) => {


### PR DESCRIPTION
There is an issue in the latest version of Firefox (Quantum, 57) where if one attempts to create multiple HTML5 Image() objects in order to load WebGL textures at the same time, it can cause some textures to become corrupted and be rendered as black squares (Seen in pixi.js). I believe this is due to the increased amount of multithreading in the latest Firefox in order to speed up performance.

Our game used a middleware to create these Image() objects, but there was no way to throttle their creation without taking the processing outside of the middleware (not ideal). To do this; i've just added an async.queue object for both before & after middleware processing, and a new concurrency argument that defaults to 1 (should have a negligible effect on performance in the vast majority of cases).

Thanks