### PR TITLE
Add test and fix for iframe sandbox cross origin behaviour.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -893,6 +893,13 @@ export default class Resource {
             return '';
         }
 
+        // A sandboxed iframe without the 'allow-same-origin' attribute will have
+        // an origin of null, and will always require crossOrigin requests
+        // regardless of whether the location matches.
+        if (window.origin === null) {
+            return 'anonymous';
+        }
+
         // default is window.location
         loc = loc || window.location;
 

--- a/test/unit/Resource.test.js
+++ b/test/unit/Resource.test.js
@@ -476,6 +476,18 @@ describe('Resource', () => {
                 { hostname: 'www.google.com', port: '123', protocol: 'https:' }
             )).to.equal('anonymous');
         });
+        it('should properly detect cross-origin requests (#5) - sandboxed iframe', () => {
+            const originalOrigin = window.origin;
+
+            // Set origin to null to simulate sandboxed iframe without 'allow-same-origin' attribute
+            window.origin = null;
+            expect(res._determineCrossOrigin(
+                'http://www.google.com:5678',
+                { hostname: 'www.google.com', port: '5678', protocol: 'http:' }
+            )).to.equal('anonymous');
+            // Restore origin to prevent test leakage.
+            window.origin = originalOrigin;
+        });
     });
 
     describe('#_getExtension', () => {


### PR DESCRIPTION
Fixes #119 

Adds a test for the new behaviour and fixes the behaviour in the case where `window.origin` is `null`.

Test passed locally (although the event tests of the Loader failed on my machine, but I don't see how anything I changed might have caused that so, assuming it will work on Travis!)