### PR TITLE
Actually check for sandboxed iframe.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -894,10 +894,11 @@ export class Resource {
             return '';
         }
 
-        // A sandboxed iframe without the 'allow-same-origin' attribute will have
-        // an origin of null, and will always require crossOrigin requests
-        // regardless of whether the location matches.
-        if (window.origin === null) {
+
+        // A sandboxed iframe without the 'allow-same-origin' attribute will have a special
+        // origin designed not to match window.location.origin, and will always require
+        // crossOrigin requests regardless of whether the location matches.
+        if (window.origin !== window.location.origin) {
             return 'anonymous';
         }
 

--- a/test/unit/Resource.test.js
+++ b/test/unit/Resource.test.js
@@ -479,8 +479,8 @@ describe('Resource', () => {
         it('should properly detect cross-origin requests (#5) - sandboxed iframe', () => {
             const originalOrigin = window.origin;
 
-            // Set origin to null to simulate sandboxed iframe without 'allow-same-origin' attribute
-            window.origin = null;
+            // Set origin to 'null' to simulate sandboxed iframe without 'allow-same-origin' attribute
+            window.origin = 'null';
             expect(res._determineCrossOrigin(
                 'http://www.google.com:5678',
                 { hostname: 'www.google.com', port: '5678', protocol: 'http:' }


### PR DESCRIPTION
Set window.origin to string in test.
Do a more rigorous check for window.origin not matching window.location.origin.

#120 attempted to implement this check, but was operating under a flawed assumption. This PR rectifies that!