### PR TITLE
Add *.mov video files support

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -48,6 +48,7 @@ export class Resource
         // videos
         mp4:        VideoLoadStrategy,
         webm:       VideoLoadStrategy,
+        mov:        VideoLoadStrategy,
     };
 
     /**


### PR DESCRIPTION
Unfortunately no ways to use webm videos on iOS and no perspectives that it should works in near future. It needs fallback video encoded using HEVC codec in mov container. That's a main reason why we need mov files support here.