### PR TITLE
Add support for multiple urlResolver functions

### DIFF
--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -68,13 +68,6 @@ export class Loader
     static readonly DefaultMiddlewarePriority = 50;
 
     /**
-     * A function or list of functions that is called when preparing a url for use.
-     * This function can be used to modify the url just prior to `baseUrl` and
-     * `defaultQueryString` being applied.
-     */
-    urlResolver: Loader.UrlResolverFn | Loader.UrlResolverFn[] | null = null;
-
-    /**
      * The progress percent of the loader going through the queue.
      */
     progress = 0;
@@ -140,6 +133,11 @@ export class Loader
      * The base url for all resources loaded by this loader.
      */
     private _baseUrl = '';
+
+    /**
+     * The internal list of URL resolver functions called within `_prepareUrl`.
+     */
+    private _urlResolvers: Loader.UrlResolverFn[] = [];
 
     /**
      * The middleware to run after loading each resource.
@@ -421,24 +419,26 @@ export class Loader
     }
 
     /**
+     * Add a function that can be used to modify the url just prior
+     * to `baseUrl` and `defaultQueryString` being applied.
+     */
+    addUrlResolver(func: Loader.UrlResolverFn): this
+    {
+        this._urlResolvers.push(func);
+        return this;
+    }
+
+    /**
      * Prepares a url for usage based on the configuration of this object
      */
     private _prepareUrl(url: string, baseUrl: string): string
     {
         let parsed = parseUri(url, { strictMode: true });
-        let resolver = this.urlResolver;
 
-        if (resolver)
-        {
-            if (!Array.isArray(resolver))
-                resolver = [resolver];
-            
-            for (let i = 0; i < resolver.length; ++i)
-            {
-                url = resolver[i](url, parsed);
-                parsed = parseUri(url, { strictMode: true });
-            }
-        }
+        this._urlResolvers.forEach(resolver => {
+            url = resolver(url, parsed);
+            parsed = parseUri(url, { strictMode: true });
+        });
 
         // Only add `baseUrl` for urls that are not absolute.
         if (!parsed.protocol && url.indexOf('//') !== 0)

--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -68,11 +68,11 @@ export class Loader
     static readonly DefaultMiddlewarePriority = 50;
 
     /**
-     * A function that is called when preparing a url for use. This function
-     * can be used to modify the url just prior to `baseUrl` and `defaultQueryString`
-     * being applied.
+     * A function or list of functions that is called when preparing a url for use.
+     * This function can be used to modify the url just prior to `baseUrl` and
+     * `defaultQueryString` being applied.
      */
-    urlResolver: Loader.UrlResolverFn | null = null;
+    urlResolver: Loader.UrlResolverFn | Loader.UrlResolverFn[] | null = null;
 
     /**
      * The progress percent of the loader going through the queue.
@@ -426,11 +426,18 @@ export class Loader
     private _prepareUrl(url: string, baseUrl: string): string
     {
         let parsed = parseUri(url, { strictMode: true });
+        let resolver = this.urlResolver;
 
-        if (this.urlResolver)
+        if (resolver)
         {
-            url = this.urlResolver(url, parsed);
-            parsed = parseUri(url, { strictMode: true });
+            if (!Array.isArray(resolver))
+                resolver = [resolver];
+            
+            for (let i = 0; i < resolver.length; ++i)
+            {
+                url = resolver[i](url, parsed);
+                parsed = parseUri(url, { strictMode: true });
+            }
         }
 
         // Only add `baseUrl` for urls that are not absolute.

--- a/test/spec/Loader.test.js
+++ b/test/spec/Loader.test.js
@@ -72,18 +72,18 @@ describe('Loader', () => {
         });
     });
 
-    describe('#urlResolver', () => {
-        it('calls urlResolver', () => {
+    describe('#addUrlResolver', () => {
+        it('calls addUrlResolver', () => {
             const spy = sinon.spy();
 
-            loader.urlResolver = () => { spy(); return ''; };
+            loader.addUrlResolver(() => { spy(); return ''; });
             loader._prepareUrl('', '');
 
             expect(spy).to.have.been.calledOnce;
         });
 
-        it('uses the result of urlResolver', () => {
-            loader.urlResolver = (s) => s.replace('{token}', 'test');
+        it('uses the result of addUrlResolver', () => {
+            loader.addUrlResolver((s) => s.replace('{token}', 'test'));
 
             const s = loader._prepareUrl('/{token}/', '/some/base/url');
 
@@ -94,7 +94,8 @@ describe('Loader', () => {
             const spy1 = sinon.spy(s => s + '/foo');
             const spy2 = sinon.spy(s => s + '/bar');
 
-            loader.urlResolver = [spy1, spy2];
+            loader.addUrlResolver(spy1)
+                .addUrlResolver(spy2);
 
             const s = loader._prepareUrl('init', '');
 
@@ -104,10 +105,8 @@ describe('Loader', () => {
         });
 
         it('supports multiple functions as urlResolver', () => {
-            loader.urlResolver = [
-                (s) => s.replace('{token}', 'foo'),
-                (s) => s.replace('{token2}', 'bar')
-            ];
+            loader.addUrlResolver((s) => s.replace('{token}', 'foo'))
+                .addUrlResolver((s) => s.replace('{token2}', 'bar'));
 
             const s = loader._prepareUrl('/{token}/{token2}/', '/some/base/url');
 

--- a/test/spec/Loader.test.js
+++ b/test/spec/Loader.test.js
@@ -89,6 +89,30 @@ describe('Loader', () => {
 
             expect(s).to.equal('/some/base/url/test/');
         });
+
+        it('calls multiple urlResolver, in order', () => {
+            const spy1 = sinon.spy(s => s + '/foo');
+            const spy2 = sinon.spy(s => s + '/bar');
+
+            loader.urlResolver = [spy1, spy2];
+
+            const s = loader._prepareUrl('init', '');
+
+            expect(spy1).to.have.been.calledOnce;
+            expect(spy2).to.have.been.calledOnce;
+            expect(s).to.equal('init/foo/bar');
+        });
+
+        it('supports multiple functions as urlResolver', () => {
+            loader.urlResolver = [
+                (s) => s.replace('{token}', 'foo'),
+                (s) => s.replace('{token2}', 'bar')
+            ];
+
+            const s = loader._prepareUrl('/{token}/{token2}/', '/some/base/url');
+
+            expect(s).to.equal('/some/base/url/foo/bar/');
+        });
     });
 
     describe('#add', () => {


### PR DESCRIPTION
### Changed

* The `urlResolver` function can now be a single function or a collection of functions
* Added unit-tests for multiple `urlResolver` functions

I tried to keep the API as simple as possible and this is probably the most conservative approach, however, but I think it could also make sense to have a `resolve` function that works like `use` and internally the loader maintains instances. 

```js
const loader = new Loader();
loader.resolve(s => s.replace('{LANG}', 'en-US'));
```

Whatever you think is best.